### PR TITLE
Enable to install tome via pip

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,36 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,124 @@
-build/
+# Mac
+.DS_Store
+
+tags
+*.onnx
+node_modules/
+*.swp
+
+# Byte-compiled / optimized / DLL files
 __pycache__/
-tomesd.egg-info/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+dotenv/local.env
+dotenv/secrets.env
+dotenv/locals/
+work
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Pycharm project setting
+.idea
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+#proxy test
+/test_proxy
+.dmypy.json
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Token Merging for Stable Diffusion
+This was forked from [the original repository](https://github.com/dbolya/tomesd) to be uploadable to Pypi
+
+## Installation
+```
+pip install tomesd
+```
+
+------------------
 
 Using nothing but pure python and pytorch, ToMe for SD speeds up diffusion by merging _redundant_ tokens.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
 # Token Merging for Stable Diffusion
-This was forked from [the original repository](https://github.com/dbolya/tomesd) to be uploadable to Pypi
-
-## Installation
-```
-pip install tomesd
-```
-
-------------------
-
 Using nothing but pure python and pytorch, ToMe for SD speeds up diffusion by merging _redundant_ tokens.
 
 ![ToMe for SD applied on a 2048x2048 image.](examples/assets/teaser.jpg)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Token Merging for Stable Diffusion
+
 Using nothing but pure python and pytorch, ToMe for SD speeds up diffusion by merging _redundant_ tokens.
 
 ![ToMe for SD applied on a 2048x2048 image.](examples/assets/teaser.jpg)

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,7 @@ setup(
     description="Token Merging for Stable Diffusion",
     install_requires=["torch"],
     packages=find_packages(exclude=("examples", "build")),
+    license = 'MIT',
+    long_description=open("README.md", "r", encoding="utf-8").read(),
+    long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
@dbolya Hi, this is a PR for pip install. 

related: https://github.com/dbolya/tomesd/issues/3

## How to publish the package
To publish the package, please follow these steps.
1. If you don't have an account in pypi, create yours in https://pypi.org/ 
2. Get your API token from https://pypi.org/manage/account/. 
3. Set the token to this repository secrets and name it `PYPI_API_TOKEN`. Please follow https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment to create a secret in the repo. 
4. Once you set the token, you're almost ready. Create whl package on your local by running:
    ```bash
    $ python setup.py bdist_wheel
    $ python setup.py clean --all
    ```
    And, you will see a whl package `tomesd-0.1-py3-none-any.whl` in `dist` folder.
5. Release your v0.1 via https://github.com/mkshing/dbolya/releases. (see the following image as a example) You can attach the whl package there!
![image](https://user-images.githubusercontent.com/33302880/229334474-94b64c4b-41f4-4e6e-89a0-51c207fd292f.png)
6. Done! Github will automatically create an action to publish your package to pypi, triggered by `publish`at step 5. https://github.com/dbolya/tomesd/actions