### PR TITLE
Feature/fixed rand generator

### DIFF
--- a/tomesd/merge.py
+++ b/tomesd/merge.py
@@ -20,7 +20,7 @@ def mps_gather_workaround(input, dim, index):
 def bipartite_soft_matching_random2d(metric: torch.Tensor,
                                      w: int, h: int, sx: int, sy: int, r: int,
                                      no_rand: bool = False,
-                                     rand_seed: int = None) -> Tuple[Callable, Callable]:
+                                     generator: torch.Generator = None) -> Tuple[Callable, Callable]:
     """
     Partitions the tokens into src and dst and merges r tokens from src to dst.
     Dst tokens are partitioned by choosing one randomy in each (sx, sy) region.
@@ -50,11 +50,7 @@ def bipartite_soft_matching_random2d(metric: torch.Tensor,
         if no_rand:
             rand_idx = torch.zeros(hsy, wsx, 1, device=metric.device, dtype=torch.int64)
         else:
-            gen = None
-            if rand_seed is not None:
-                gen = torch.Generator(device=metric.device)
-                gen = gen.manual_seed(rand_seed)
-            rand_idx = torch.randint(sy*sx, size=(hsy, wsx, 1), device=metric.device, generator=gen)
+            rand_idx = torch.randint(sy*sx, size=(hsy, wsx, 1), device=metric.device, generator=generator)
         
         # The image might not divide sx and sy, so we need to work on a view of the top left if the idx buffer instead
         idx_buffer_view = torch.zeros(hsy, wsx, sy*sx, device=metric.device, dtype=torch.int64)

--- a/tomesd/patch.py
+++ b/tomesd/patch.py
@@ -18,10 +18,12 @@ def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any]) -> Tuple[Callable,
         w = int(math.ceil(original_w / downsample))
         h = int(math.ceil(original_h / downsample))
         r = int(x.shape[1] * args["ratio"])
-        # If the batch size is odd, then it's not possible for promted and unprompted images to be in the same
+        # If the batch size is odd, then it's not possible for prompted and unprompted images to be in the same
         # batch, which causes artifacts with use_rand, so force it to be off.
         use_rand = False if x.shape[0] % 2 == 1 else args["use_rand"]
-        m, u = merge.bipartite_soft_matching_random2d(x, w, h, args["sx"], args["sy"], r, not use_rand)
+        rand_seed = None if x.shape[0] % 2 == 1 else args["rand_seed"]
+        m, u = merge.bipartite_soft_matching_random2d(x, w, h, args["sx"], args["sy"], r, 
+                                                      no_rand=not use_rand, rand_seed=rand_seed)
     else:
         m, u = (merge.do_nothing, merge.do_nothing)
 
@@ -176,6 +178,7 @@ def apply_patch(
         max_downsample: int = 1,
         sx: int = 2, sy: int = 2,
         use_rand: bool = True,
+        rand_seed: int = None,
         merge_attn: bool = True,
         merge_crossattn: bool = False,
         merge_mlp: bool = False):
@@ -224,6 +227,7 @@ def apply_patch(
             "max_downsample": max_downsample,
             "sx": sx, "sy": sy,
             "use_rand": use_rand,
+            "rand_seed": rand_seed,
             "merge_attn": merge_attn,
             "merge_crossattn": merge_crossattn,
             "merge_mlp": merge_mlp

--- a/tomesd/patch.py
+++ b/tomesd/patch.py
@@ -7,7 +7,7 @@ from .utils import isinstance_str
 
 
 
-def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any]) -> Tuple[Callable, ...]:
+def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any], tome_generator: torch.Generator = None) -> Tuple[Callable, ...]:
     original_h, original_w = tome_info["size"]
     original_tokens = original_h * original_w
     downsample = int(math.ceil(math.sqrt(original_tokens // x.shape[1])))
@@ -21,8 +21,8 @@ def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any]) -> Tuple[Callable,
         # If the batch size is odd, then it's not possible for prompted and unprompted images to be in the same
         # batch, which causes artifacts with use_rand, so force it to be off.
         use_rand = False if x.shape[0] % 2 == 1 else args["use_rand"]
-        generator = None if x.shape[0] % 2 == 1 else args["generator"]
-        m, u = merge.bipartite_soft_matching_random2d(x, w, h, args["sx"], args["sy"], r, 
+        generator = None if x.shape[0] % 2 == 1 else tome_generator
+        m, u = merge.bipartite_soft_matching_random2d(x, w, h, args["sx"], args["sy"], r,
                                                       no_rand=not use_rand, generator=generator)
     else:
         m, u = (merge.do_nothing, merge.do_nothing)
@@ -50,7 +50,7 @@ def make_tome_block(block_class: Type[torch.nn.Module]) -> Type[torch.nn.Module]
         _parent = block_class
 
         def _forward(self, x: torch.Tensor, context: torch.Tensor = None) -> torch.Tensor:
-            m_a, m_c, m_m, u_a, u_c, u_m = compute_merge(x, self._tome_info)
+            m_a, m_c, m_m, u_a, u_c, u_m = compute_merge(x, self._tome_info, self._tome_generator)
 
             # This is where the meat of the computation happens
             x = u_a(self.attn1(m_a(self.norm1(x)), context=context if self.disable_self_attn else None)) + x
@@ -86,7 +86,7 @@ def make_diffusers_tome_block(block_class: Type[torch.nn.Module]) -> Type[torch.
             class_labels=None,
         ) -> torch.Tensor:
             # (1) ToMe
-            m_a, m_c, m_m, u_a, u_c, u_m = compute_merge(hidden_states, self._tome_info)
+            m_a, m_c, m_m, u_a, u_c, u_m = compute_merge(hidden_states, self._tome_info, self._tome_generator)
 
             if self.use_ada_layer_norm:
                 norm_hidden_states = self.norm1(hidden_states, timestep)
@@ -227,7 +227,6 @@ def apply_patch(
             "max_downsample": max_downsample,
             "sx": sx, "sy": sy,
             "use_rand": use_rand,
-            "generator": None,
             "merge_attn": merge_attn,
             "merge_crossattn": merge_crossattn,
             "merge_mlp": merge_mlp
@@ -243,9 +242,11 @@ def apply_patch(
             module.__class__ = make_tome_block_fn(module.__class__)
             module._tome_info = diffusion_model._tome_info
             if rand_seed is not None:
-                module._tome_info["args"]["generator"] = torch.Generator(device=diffusion_model.device)
-                module._tome_info["args"]["generator"] = module._tome_info["args"]["generator"].manual_seed(rand_seed + layer_ctr)
+                module._tome_generator = torch.Generator(device=diffusion_model.device)
+                module._tome_generator = module._tome_generator.manual_seed(rand_seed + layer_ctr)
                 layer_ctr += 1
+            else:
+                module._tome_generator = None
 
             # Something introduced in SD 2.0 (LDM only)
             if not hasattr(module, "disable_self_attn") and not is_diffusers:

--- a/tomesd/patch.py
+++ b/tomesd/patch.py
@@ -7,6 +7,20 @@ from .utils import isinstance_str
 
 
 
+def init_generator(device: torch.device):
+    """
+    Forks the current default random generator given device.
+    """
+    if device.type == "cpu":
+        return torch.Generator(device=device).set_state(torch.get_rng_state())
+    elif device.type == "cuda":
+        return torch.Generator(device=device).set_state(torch.cuda.get_rng_state())
+    elif device.type == "mps":
+        return torch.Generator(device=device).set_state(torch.mps.get_rng_state())
+    raise NotImplementedError(f"Invalid/unsupported device. Expected `cpu`, `cuda`, or `mps`, got {device.type}.")
+
+
+
 def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any]) -> Tuple[Callable, ...]:
     original_h, original_w = tome_info["size"]
     original_tokens = original_h * original_w
@@ -20,6 +34,8 @@ def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any]) -> Tuple[Callable,
         r = int(x.shape[1] * args["ratio"])
         # If the batch size is odd, then it's not possible for prompted and unprompted images to be in the same
         # batch, which causes artifacts with use_rand, so force it to be off.
+        if args["generator"] is None or args["generator"].device != x.device:
+            args["generator"] = init_generator(x.device)
         use_rand = False if x.shape[0] % 2 == 1 else args["use_rand"]
         generator = None if x.shape[0] % 2 == 1 else args["generator"]
         m, u = merge.bipartite_soft_matching_random2d(x, w, h, args["sx"], args["sy"], r, 
@@ -178,7 +194,6 @@ def apply_patch(
         max_downsample: int = 1,
         sx: int = 2, sy: int = 2,
         use_rand: bool = True,
-        rand_seed: int = None,
         merge_attn: bool = True,
         merge_crossattn: bool = False,
         merge_mlp: bool = False):
@@ -219,11 +234,6 @@ def apply_patch(
         # Supports "pipe.unet" and "unet"
         diffusion_model = model.unet if hasattr(model, "unet") else model
 
-    generator = None
-    if rand_seed is not None:
-        generator = torch.Generator(device=diffusion_model.device)
-        generator = generator.manual_seed(rand_seed)
-
     diffusion_model._tome_info = {
         "size": None,
         "hooks": [],
@@ -232,7 +242,7 @@ def apply_patch(
             "max_downsample": max_downsample,
             "sx": sx, "sy": sy,
             "use_rand": use_rand,
-            "generator": generator,
+            "generator": None,
             "merge_attn": merge_attn,
             "merge_crossattn": merge_crossattn,
             "merge_mlp": merge_mlp


### PR DESCRIPTION
When `use_rand` is enabled, the fact that token indices are being generated using the default generator results in future rand calls to be offset. This appears to be the reason why in some cases, ToMe generates images that are slightly different from what SD would generate with the same random seed.

While some non-determinism is unavoidable on CUDA specifically, this can be avoided by using an independent rand generator for that one step.

With this commit, the behavior remains unchanged if `use_rand` is enabled, just to ensure consistency. However, if `rand_seed` is set to any integer, the independent generator will be used and images will start to look more like what SD would produce.

Here's a few examples:

From right to left are image generated after applying ToMe, image generated without ToMe, image generated with ToMe without randomness, image generated with this commit (unchanged behavior), and image generated with this commit with the random seed set to an integer.

![Astronaut on horse in Mars](https://user-images.githubusercontent.com/68103095/234114959-b30a3727-012d-4276-89a7-c2fb408593aa.png)
![Temple in ruins](https://user-images.githubusercontent.com/68103095/234115013-ce17bb02-5bf4-4a80-b877-8f7959a00030.png)
![Castle view](https://user-images.githubusercontent.com/68103095/234115104-f08807fa-b3d8-4044-9e5c-99af3083d431.png)

