### PR TITLE
Update for StableVideoDiffusionPipeline

### DIFF
--- a/tomesd/patch.py
+++ b/tomesd/patch.py
@@ -1,9 +1,10 @@
 import torch
 import math
-from typing import Type, Dict, Any, Tuple, Callable
+from typing import Optional, Type, Dict, Any, Tuple, Callable
 
 from . import merge
 from .utils import isinstance_str, init_generator
+from torch import nn
 
 
 
@@ -39,9 +40,60 @@ def compute_merge(x: torch.Tensor, tome_info: Dict[str, Any]) -> Tuple[Callable,
 
     return m_a, m_c, m_m, u_a, u_c, u_m  # Okay this is probably not very good
 
+def compute_temporal_merge(x: torch.Tensor, tome_info: Dict[str, Any], original_num_frames) -> Tuple[Callable, ...]:
+    original_tokens = original_num_frames * original_num_frames
+    downsample = int(math.ceil(math.sqrt(original_tokens // x.shape[1])))
 
+    args = tome_info["args"]
 
+    if downsample <= args["max_downsample"]:
+        n = int(math.ceil(original_num_frames / downsample))
+        r = int(x.shape[1] * args["ratio"])
 
+        # Re-init the generator if it hasn't already been initialized or device has changed.
+        if args["generator"] is None:
+            args["generator"] = init_generator(x.device)
+        elif args["generator"].device != x.device:
+            args["generator"] = init_generator(x.device, fallback=args["generator"])
+        
+        # If the batch size is odd, then it's not possible for prompted and unprompted images to be in the same
+        # batch, which causes artifacts with use_rand, so force it to be off.
+        use_rand = False if x.shape[0] % 2 == 1 else args["use_rand"]
+        m, u = merge.bipartite_soft_matching_random2d(x, n, n, args["sx"], args["sy"], r, 
+                                                      no_rand=not use_rand, generator=args["generator"])
+    else:
+        m, u = (merge.do_nothing, merge.do_nothing)
+
+    m_a, u_a = (m, u) if args["temporal_merge_attn"]      else (merge.do_nothing, merge.do_nothing)
+    m_c, u_c = (m, u) if args["temporal_merge_crossattn"] else (merge.do_nothing, merge.do_nothing)
+    m_m, u_m = (m, u) if args["temporal_merge_mlp"]       else (merge.do_nothing, merge.do_nothing)
+
+    return m_a, m_c, m_m, u_a, u_c, u_m  # Okay this is probably not very good
+
+# from https://github.com/huggingface/diffusers/blob/f72b28c75b2b4b720a5d8de78556694cf4b893fd/src/diffusers/models/attention.py#L363
+def _chunked_feed_forward(
+    ff: nn.Module, hidden_states: torch.Tensor, chunk_dim: int, chunk_size: int, lora_scale: Optional[float] = None
+):
+    # "feed_forward_chunk_size" can be used to save memory
+    if hidden_states.shape[chunk_dim] % chunk_size != 0:
+        raise ValueError(
+            f"`hidden_states` dimension to be chunked: {hidden_states.shape[chunk_dim]} has to be divisible by chunk size: {chunk_size}. Make sure to set an appropriate `chunk_size` when calling `unet.enable_forward_chunking`."
+        )
+
+    num_chunks = hidden_states.shape[chunk_dim] // chunk_size
+    if lora_scale is None:
+        ff_output = torch.cat(
+            [ff(hid_slice) for hid_slice in hidden_states.chunk(num_chunks, dim=chunk_dim)],
+            dim=chunk_dim,
+        )
+    else:
+        # TOOD(Patrick): LoRA scale can be removed once PEFT refactor is complete
+        ff_output = torch.cat(
+            [ff(hid_slice, scale=lora_scale) for hid_slice in hidden_states.chunk(num_chunks, dim=chunk_dim)],
+            dim=chunk_dim,
+        )
+
+    return ff_output
 
 
 
@@ -81,6 +133,7 @@ def make_diffusers_tome_block(block_class: Type[torch.nn.Module]) -> Type[torch.
         # Save for unpatching later
         _parent = block_class
 
+        # copied from 
         def forward(
             self,
             hidden_states,
@@ -158,6 +211,92 @@ def make_diffusers_tome_block(block_class: Type[torch.nn.Module]) -> Type[torch.
 
     return ToMeBlock
 
+def make_diffusers_tome_temporal_block(block_class: Type[torch.nn.Module]) -> Type[torch.nn.Module]:
+    """
+    Make a patched class for a diffusers model.
+    This patch applies ToMe to the forward function of the block.
+    """
+    class ToMeTemporalBlock(block_class):
+        # Save for unpatching later
+        _parent = block_class
+
+        # copied from https://github.com/huggingface/diffusers/blob/f72b28c75b2b4b720a5d8de78556694cf4b893fd/src/diffusers/models/attention.py#L435
+        def forward(
+            self,
+            hidden_states,
+            num_frames,
+            encoder_hidden_states = None,
+        ):
+            # Notice that normalization is always applied before the real computation in the following blocks.
+            # 0. Self-Attention
+            batch_size = hidden_states.shape[0]
+
+            batch_frames, seq_length, channels = hidden_states.shape
+            batch_size = batch_frames // num_frames
+
+            hidden_states = hidden_states[None, :].reshape(batch_size, num_frames, seq_length, channels)
+            hidden_states = hidden_states.permute(0, 2, 1, 3)
+            hidden_states = hidden_states.reshape(batch_size * seq_length, num_frames, channels)
+
+            # (1) ToMe
+            m_a, m_c, m_m, u_a, u_c, u_m = compute_temporal_merge(hidden_states, self._tome_info, num_frames)
+
+            residual = hidden_states
+            hidden_states = self.norm_in(hidden_states)
+
+            if self._chunk_size is not None:
+                hidden_states = _chunked_feed_forward(self.ff, hidden_states, self._chunk_dim, self._chunk_size)
+            else:
+                hidden_states = self.ff_in(hidden_states)
+
+            if self.is_res:
+                hidden_states = hidden_states + residual
+
+            norm_hidden_states = self.norm1(hidden_states)
+            # (2) ToMe m_a
+            norm_hidden_states = m_a(norm_hidden_states)
+
+            attn_output = self.attn1(norm_hidden_states, encoder_hidden_states=None)
+            # (3) ToMe u_a
+            hidden_states = u_a(attn_output) + hidden_states
+
+            # 3. Cross-Attention
+            if self.attn2 is not None:
+                norm_hidden_states = self.norm2(hidden_states)
+
+                # (4) ToMe m_c
+                norm_hidden_states = m_c(norm_hidden_states)
+
+                attn_output = self.attn2(norm_hidden_states, encoder_hidden_states=encoder_hidden_states)
+
+                # (5) ToMe u_c
+                hidden_states = u_c(attn_output) + hidden_states
+
+            # 4. Feed-forward
+            norm_hidden_states = self.norm3(hidden_states)
+
+            # (6) ToMe m_m
+            norm_hidden_states = m_m(norm_hidden_states)
+
+            if self._chunk_size is not None:
+                ff_output = _chunked_feed_forward(self.ff, norm_hidden_states, self._chunk_dim, self._chunk_size)
+            else:
+                ff_output = self.ff(norm_hidden_states)
+
+            if self.is_res:
+                # (7) ToMe u_m
+                hidden_states = u_m(ff_output) + hidden_states
+            else:
+                # (7) ToMe u_m
+                hidden_states = u_m(ff_output)
+
+            hidden_states = hidden_states[None, :].reshape(batch_size, seq_length, num_frames, channels)
+            hidden_states = hidden_states.permute(0, 2, 1, 3)
+            hidden_states = hidden_states.reshape(batch_size * num_frames, seq_length, channels)
+
+            return hidden_states
+
+    return ToMeTemporalBlock
 
 
 
@@ -166,7 +305,12 @@ def make_diffusers_tome_block(block_class: Type[torch.nn.Module]) -> Type[torch.
 def hook_tome_model(model: torch.nn.Module):
     """ Adds a forward pre hook to get the image size. This hook can be removed with remove_patch. """
     def hook(module, args):
-        module._tome_info["size"] = (args[0].shape[2], args[0].shape[3])
+        shape = args[0].shape
+        if len(shape) == 5:
+            # video model
+            module._tome_info["size"] = (args[0].shape[3], args[0].shape[4])
+        else:
+            module._tome_info["size"] = (args[0].shape[2], args[0].shape[3])
         return None
 
     model._tome_info["hooks"].append(model.register_forward_pre_hook(hook))
@@ -186,7 +330,11 @@ def apply_patch(
         use_rand: bool = True,
         merge_attn: bool = True,
         merge_crossattn: bool = False,
-        merge_mlp: bool = False):
+        merge_mlp: bool = False,
+        temporal_merge_attn: bool = True,
+        temporal_merge_crossattn: bool = False,
+        temporal_merge_mlp: bool = False,
+        ):
     """
     Patches a stable diffusion model with ToMe.
     Apply this to the highest level stable diffusion object (i.e., it should have a .model.diffusion_model).
@@ -235,7 +383,10 @@ def apply_patch(
             "generator": None,
             "merge_attn": merge_attn,
             "merge_crossattn": merge_crossattn,
-            "merge_mlp": merge_mlp
+            "merge_mlp": merge_mlp,
+            "temporal_merge_attn": temporal_merge_attn,
+            "temporal_merge_crossattn": temporal_merge_crossattn,
+            "temporal_merge_mlp": temporal_merge_mlp
         }
     }
     hook_tome_model(diffusion_model)
@@ -256,6 +407,10 @@ def apply_patch(
                 module.use_ada_layer_norm = False
                 module.use_ada_layer_norm_zero = False
 
+        elif isinstance_str(module, "TemporalBasicTransformerBlock"):
+            module.__class__ = make_diffusers_tome_temporal_block(module.__class__)
+            module._tome_info = diffusion_model._tome_info
+
     return model
 
 
@@ -273,7 +428,7 @@ def remove_patch(model: torch.nn.Module):
                 hook.remove()
             module._tome_info["hooks"].clear()
 
-        if module.__class__.__name__ == "ToMeBlock":
+        if module.__class__.__name__ == "ToMeBlock" or module.__class__.__name__ == "ToMeTemporalBlock":
             module.__class__ = module._parent
     
     return model


### PR DESCRIPTION
I've updated the code so it is compatible with the `StableVideoDiffusionPipeline`. It handles the 5 dimensional input and applies token merging to the temporal attention. 

Temporal attention is not a major performance bottleneck but there is a lot of redundancy and I wanted to see if it would work. 

I have a repo for testing it here: https://github.com/jfischoff/svd-tomesd